### PR TITLE
Return value in getRandomValues

### DIFF
--- a/lib/wasm_exec.js
+++ b/lib/wasm_exec.js
@@ -106,7 +106,7 @@
 		const nodeCrypto = require("crypto");
 		global.crypto = {
 			getRandomValues(b) {
-				nodeCrypto.randomFillSync(b);
+				return nodeCrypto.randomFillSync(b);
 			},
 		};
 	}


### PR DESCRIPTION
### Description

`getRandomValues` is missing a return, which was causing weird behavior in unrelated dependencies. 